### PR TITLE
fix(sql): prevent race condition on render and table reload

### DIFF
--- a/smoothcsv-app-modules/smoothcsv-core/src/main/java/com/smoothcsv/core/sql/component/SqlToolsDialog.java
+++ b/smoothcsv-app-modules/smoothcsv-core/src/main/java/com/smoothcsv/core/sql/component/SqlToolsDialog.java
@@ -119,7 +119,6 @@ public class SqlToolsDialog extends DialogBase {
       public void componentShown(ComponentEvent componentEvent) {
 
         tableListPanel.stopEditing();
-        tableListPanel.loadCsvSheetTables();
 
         if (!initialized) {
           splitPane.setResizeWeight(0);
@@ -153,6 +152,10 @@ public class SqlToolsDialog extends DialogBase {
   public void stopTableNameEdition() {
     tableListPanel.stopEditing();
     tableColumnsEditorPanel.stopEditiong();
+  }
+
+  public void loadCsvSheetTables() {
+    tableListPanel.loadCsvSheetTables();
   }
 
   @Override

--- a/smoothcsv-app-modules/smoothcsv-core/src/main/java/command/app/ShowSqlToolsCommand.java
+++ b/smoothcsv-app-modules/smoothcsv-core/src/main/java/command/app/ShowSqlToolsCommand.java
@@ -30,6 +30,10 @@ public class ShowSqlToolsCommand extends Command {
 
     if (dialog == null) {
       dialog = new SqlToolsDialog();
+    } else {
+      // Load here to avoid race condition on painting raising a
+      // java.lang.NullPointerException.
+      dialog.loadCsvSheetTables();
     }
     dialog.setVisible(true);
   }


### PR DESCRIPTION
Hi, amazing tool!
This PR solves and issue where a `NullPointerException` is thrown every time a tab is closed and SQL dialog is opened.

Steps to replicate:
 * Start Smoothcsv
 * Add a new empty file (so you have two)
 * Open SQL dialog
 * Close SQL dialog
 * Close one of the empty files
 * Open SQL dialog
 
An error dialog should now appear and the rendering of the SQL dialog should be compromised.
I am using SmoothCSV on a Mac, in case this makes a difference.